### PR TITLE
fix formtools dependency link

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ setup(
     author_email='info@divio.ch',
     url='https://github.com/aldryn/aldryn-django',
     packages=find_packages(),
-    dependency_links = [
-        "https://control-panel-live-extra-packages.s3.amazonaws.com/django-formtools/django-formtools-1.0.0.1.tar.gz#egg=django-formtools-1.0.0.1",
-    ],
+    dependency_links=(
+        "https://control-panel-live-extra-packages.s3.amazonaws.com/django-formtools/django-formtools-1.0.0.1.tar.gz#egg=django-formtools",
+    ),
     install_requires=(
         'aldryn-addons',
         # security backport of Django from


### PR DESCRIPTION
The version part is not required, but fixing installs :)

Quoting pip docs:

> The "project name" component of the url suffix "egg=<project name>-<version>" is used by pip in its dependency logic to identify the project prior to pip downloading and analyzing the metadata. The optional "version" component of the egg name is not functionally important. It merely provides a human-readable clue as to what version is in use.
> _https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support_
