### PR TITLE
fix collectstatic cache error at build time

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -30,11 +30,15 @@ class Form(forms.BaseForm):
         settings['DEBUG'] = boolean_ish(env('DEBUG', False))
 
         settings['DATABASE_URL'] = env('DATABASE_URL')
-        if settings['DATABASE_URL']:
-            pass
-        elif env('DJANGO_MODE') == 'build':
+        settings['CACHE_URL'] = env('CACHE_URL')
+        if env('DJANGO_MODE') == 'build':
+            # In build mode we don't have any connected services like db or
+            # cache available. So we need to configure those things in a way
+            # they can run without real backends.
             settings['DATABASE_URL'] = 'sqlite://:memory:'
-        else:
+            settings['CACHE_URL'] = 'locmem://'
+
+        if not settings['DATABASE_URL']:
             settings['DATABASE_URL'] = 'sqlite:///{}'.format(
                 os.path.join(settings['DATA_ROOT'], 'db.sqlite3')
             )
@@ -44,6 +48,15 @@ class Form(forms.BaseForm):
                 ),
                 RuntimeWarning,
             )
+        if not settings['CACHE_URL']:
+            settings['CACHE_URL'] = 'locmem://'
+            warnings.warn(
+                'no cache configured. Falling back to CACHE_URL={0}'.format(
+                    settings['CACHE_URL']
+                ),
+                RuntimeWarning,
+            )
+
         settings['DATABASES']['default'] = dj_database_url.parse(settings['DATABASE_URL'])
 
         settings['ROOT_URLCONF'] = env('ROOT_URLCONF', 'urls')


### PR DESCRIPTION
fixes a problem where at build time most management commands, like
collectstatic, don't work. A change in Django 1.8 or django-cms (I'm not
sure which) caused the cache to be used at import time and exploding if
it is not configured.
