### PR TITLE
add --master mode for uwsgi

### DIFF
--- a/aldryn_django/cli.py
+++ b/aldryn_django/cli.py
@@ -87,6 +87,7 @@ def start_uwsgi_command(settings, port=None):
         'uwsgi',
         '--module=wsgi',
         '--http=0.0.0.0:{}'.format(port or settings.get('PORT')),
+        '--master',
         '--workers={}'.format(settings['DJANGO_WEB_WORKERS']),
         '--max-requests={}'.format(settings['DJANGO_WEB_MAX_REQUESTS']),
         '--harakiri={}'.format(settings['DJANGO_WEB_TIMEOUT']),


### PR DESCRIPTION
without this uwsgi will not be able to handle more requests at the same
time as there are workers. (that is bad)
