### PR TITLE
django-secure support (https and others)

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -135,6 +135,7 @@ class Form(forms.BaseForm):
         settings['SITE_ID'] = env('SITE_ID', 1)
 
         self.domain_settings(data, settings, env=env)
+        self.security_settings(data, settings, env=env)
         self.server_settings(settings, env=env)
         self.logging_settings(settings, env=env)
         # Order matters, sentry settings rely on logging being configured.
@@ -176,6 +177,30 @@ class Form(forms.BaseForm):
         settings['MIDDLEWARE_CLASSES'].insert(
             settings['MIDDLEWARE_CLASSES'].index('django.middleware.common.CommonMiddleware'),
             'aldryn_sites.middleware.SiteMiddleware',
+        )
+
+    def security_settings(self, data, settings, env):
+        s = settings
+        s['SECURE_SSL_REDIRECT'] = env('SECURE_SSL_REDIRECT', False)
+        s['SECURE_REDIRECT_EXEMPT'] = env('SECURE_REDIRECT_EXEMPT', [])
+        s['SECURE_HSTS_SECONDS'] = env('SECURE_HSTS_SECONDS', 0)
+        s['SESSION_COOKIE_SECURE'] = env('SESSION_COOKIE_SECURE', False)
+        s['SECURE_PROXY_SSL_HEADER'] = env(
+            'SECURE_PROXY_SSL_HEADER',
+            ('HTTP_X_FORWARDED_PROTO', 'https')
+        )
+        # SESSION_COOKIE_HTTPONLY and SECURE_FRAME_DENY must be False for CMS
+        s['SESSION_COOKIE_HTTPONLY'] = env('SESSION_COOKIE_HTTPONLY', False)
+        s['SECURE_FRAME_DENY'] = env('SECURE_FRAME_DENY', False)
+
+        s['SECURE_CONTENT_TYPE_NOSNIFF'] = env('SECURE_CONTENT_TYPE_NOSNIFF', False)
+        s['SECURE_BROWSER_XSS_FILTER'] = env('SECURE_BROWSER_XSS_FILTER', False)
+
+
+        s['INSTALLED_APPS'].append('djangosecure')
+        s['MIDDLEWARE_CLASSES'].insert(
+            s['MIDDLEWARE_CLASSES'].index('aldryn_sites.middleware.SiteMiddleware') + 1,
+            'djangosecure.middleware.SecurityMiddleware'
         )
 
     def server_settings(self, settings, env):

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,15 @@ setup(
         'boto',
         'djeese-fs',
 
-        # security related (insecure platform warnings)
+        # security: avoid python insecure platform warnings
         'cryptography',
         'ndg-httpsclient',
         'certifi',
         'pyOpenSSL',
+
+        # security
+        'django-secure',
+
         # helpers
         'aldryn-sites>=0.5.2',
 


### PR DESCRIPTION
controls http->https redirects based on environment variables:

`SECURE_SSL_REDIRECT=True`

Also sets other security related options. Currently leans to most
compatible rather than most secure, in order to prevent hard to debug
errors with existing sites.

The defaults may be tweaked at a later stage.
