### PR TITLE
Correct serialization for forego

### DIFF
--- a/aldryn_django/cli.py
+++ b/aldryn_django/cli.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 import os
 import subprocess
 import sys
-import yaml
 
 from django.conf import settings as django_settings
 from django.template import loader, Context
@@ -194,14 +193,17 @@ def start_with_nginx(settings):
         raise click.UsageError(
             'NGINX_CONF_PATH and NGINX_PROCFILE_PATH must be configured'
         )
-    procfile = yaml.safe_dump(
-        {
-            'nginx': 'nginx',
-            'django': ' '.join(
-                start_uwsgi_command(settings, port=settings['BACKEND_PORT'])
-            )
-        },
-        default_flow_style=False,
+
+    commands = {
+        'nginx': 'nginx',
+        'django': ' '.join(
+            start_uwsgi_command(settings, port=settings['BACKEND_PORT'])
+        )
+    }
+
+    procfile = '\n'.join(
+        '{} {}'.format(name, command)
+        for name, command in commands.items()
     )
 
     if (

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         'django-getenv',
         'aldryn-client',
         'webservices',
-        'pyaml',
         'yurl',
 
         # error reporting


### PR DESCRIPTION
The yaml serializer used to write out the Procfile causes line breaks
to be added to the file when a command is too long.

Forego (or whatever we're using to run Procfiles) does not use yaml to
load the Procfiles, and as such trims off a part of the commands.

As our procfile is relatively simple, and as it is not yaml anyway,
simply put a string together manually and remove the pyaml dependency.
