### PR TITLE
Fixes compatibility error with djangocms-link

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         # version of Django is being installed, so these stay here.
         # These packages require djangocms-attributes-field which requires
         # Django 1.8+.
-        'djangocms-link<1.8.0',
+        'djangocms-link<1.7.2',
         'cmsplugin-filer<1.1.0',
         # 'aldryn-bootstrap3<1.1.0',
 


### PR DESCRIPTION
This commit https://github.com/divio/djangocms-link/commit/00947004f1f698eaa8bb0ef6b530a17dd470b07d introduced a change that's not 1.6 compatible due to a Django bug.
