### PR TITLE
fix issue in GZippedStaticFilesMixin.gzip_path with py3

### DIFF
--- a/aldryn_django/storage.py
+++ b/aldryn_django/storage.py
@@ -206,7 +206,7 @@ class GZippedStaticFilesMixin(object):
     def gzip_path(self, path):
         gz_path = path + '.gz'
         with self.open(path) as f_in:
-            with self.open(gz_path, 'w') as f_out:
+            with self.open(gz_path, 'wb') as f_out:
                 with gzip.GzipFile(fileobj=f_out) as gz_out:
                     shutil.copyfileobj(f_in, gz_out)
         return gz_path


### PR DESCRIPTION
the problem on python3:

``` python
>>> gzip.GzipFile(fileobj=open('tmp', 'w'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/gzip.py", line 192, in __init__
    self._write_gzip_header()
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/gzip.py", line 220, in _write_gzip_header
    self.fileobj.write(b'\037\213')             # magic header
TypeError: write() argument must be str, not bytes
```

this worked perfectly fine in python2:

``` python
>>> gzip.GzipFile(fileobj=open('tmp', 'w'))
<gzip open file 'tmp', mode 'w' at 0x10ce3a6f0 0x10ceb5090>
```

The fix that works with both python versions is to specifically define to file open mode as write-_binary_:

Python 3

``` python
>>> gzip.GzipFile(fileobj=open('tmp', 'wb'))
<gzip _io.BufferedWriter name='tmp' 0x7efebacec080>
```

Python 2

``` python
>>> gzip.GzipFile(fileobj=open('tmp', 'wb'))
<gzip open file 'tmp', mode 'wb' at 0x10ce3a8a0 0x10ceb5110>
```
