### PR TITLE
fix: build mode cache if CACHE_URL env var is set

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -71,6 +71,7 @@ class Form(forms.BaseForm):
     )
 
     def to_settings(self, data, settings):
+        import django_cache_url
         import dj_database_url
         import warnings
         from functools import partial
@@ -106,6 +107,8 @@ class Form(forms.BaseForm):
                 ),
                 RuntimeWarning,
             )
+        settings['DATABASES']['default'] = dj_database_url.parse(settings['DATABASE_URL'])
+
         if not settings['CACHE_URL']:
             settings['CACHE_URL'] = 'locmem://'
             warnings.warn(
@@ -114,8 +117,7 @@ class Form(forms.BaseForm):
                 ),
                 RuntimeWarning,
             )
-
-        settings['DATABASES']['default'] = dj_database_url.parse(settings['DATABASE_URL'])
+        settings['CACHES']['default'] = django_cache_url.parse(settings['CACHE_URL'])
 
         settings['ROOT_URLCONF'] = env('ROOT_URLCONF', 'urls')
         settings['ADDON_URLS'].append('aldryn_django.urls')
@@ -194,7 +196,6 @@ class Form(forms.BaseForm):
         self.logging_settings(settings, env=env)
         # Order matters, sentry settings rely on logging being configured.
         self.sentry_settings(settings, env=env)
-        self.cache_settings(settings, env=env)
         self.storage_settings_for_media(settings, env=env)
         self.storage_settings_for_static(data, settings, env=env)
         self.email_settings(data, settings, env=env)
@@ -381,12 +382,6 @@ class Form(forms.BaseForm):
                 'level': 'ERROR',
                 'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
             }
-
-    def cache_settings(self, settings, env):
-        import django_cache_url
-        cache_url = env('CACHE_URL')
-        if cache_url:
-            settings['CACHES']['default'] = django_cache_url.parse(cache_url)
 
     def storage_settings_for_media(self, settings, env):
         import yurl


### PR DESCRIPTION
Previously the the CACHE_URL environment variable would take precedence
in build mode. But if build mode is active we always want to use the
safe backends for DATABASE_URL and CACHE_URL.
Also made the code flow easier to understand.
