### PR TITLE
Django 2.0 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(),
     install_requires=(
         'aldryn-addons',
-        'Django==1.11.5',
+        'Django==2.0',
 
         # setup utils
         'dj-database-url',


### PR DESCRIPTION
# Django 2.0 support (**WIP!**)

Adding support for Django 2.0 is a bit more complicated than just bumping the version.
``MIDDLEWARE_CLASSES`` has been removed and replaced by a new system. All dependencies that have middlewares need to be made compatible.

# How to code on this PR

Setup a (pure django) divio cloud project with python3 and check out all the packages mentioned below into the addons-dev folder and switch to the mentioned branches. Also, remove the ``MIDDLEWARE_CLASSES`` line in ``settings.py`` if it exists.

# Progress

- [x] make a ``support/2.0.x`` branch
- [x] bump version in ``setup.py`` 
- [ ] figure out ``MIDDLEWARE_CLASSES`` replacement (https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-middleware)
  - [ ] make aldryn-addons compatible (https://github.com/aldryn/aldryn-addons/pull/8)
  - [ ] aldryn-sso (https://github.com/aldryn/aldryn-sso/pull/49)
    - [ ] simple-sso (``django.core.urlresolvers.reverse`` -> ``django.urls.reverse``)
- [ ] ...

## Phase 2:
  - [ ] aldryn-django-cms / django-cms