### PR TITLE
Pinned Django Storages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'click',
 
         # storage
-        'django-storages',
+        'django-storages<=1.6.6',
         'boto>=2.40.0',
         'djeese-fs',
 


### PR DESCRIPTION
django-storages>1.6.6 requires Django 1.11 or newer; this pins
django-storages to <=1.6.6.