### PR TITLE
Allow users to configure aldryn sites redirect type via env variable …

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -221,6 +221,8 @@ class Form(forms.BaseForm):
         return settings
 
     def domain_settings(self, data, settings, env):
+        from aldryn_addons.utils import boolean_ish
+
         settings['ALLOWED_HOSTS'] = env('ALLOWED_HOSTS', ['localhost', '*'])
         # will take a full config dict from ALDRYN_SITES_DOMAINS if available,
         # otherwise fall back to constructing the dict from DOMAIN,
@@ -230,6 +232,8 @@ class Form(forms.BaseForm):
             settings['DOMAIN'] = domain
 
         domains = env('ALDRYN_SITES_DOMAINS', {})
+        permanent_redirect = boolean_ish(env('ALDRYN_SITES_REDIRECT_PERMANENT', False))
+
         if not domains and domain:
             domain_aliases = [
                 d.strip()
@@ -250,6 +254,7 @@ class Form(forms.BaseForm):
                 },
             }
         settings['ALDRYN_SITES_DOMAINS'] = domains
+        settings['ALDRYN_SITES_REDIRECT_PERMANENT'] = permanent_redirect
 
         # This is ensured again by aldryn-sites, but we already do it here
         # as we need the full list of domains later when configuring


### PR DESCRIPTION
…(#88)

Restores support for `ALDRYN_SITES_REDIRECT_PERMANENT`.