### PR TITLE
Bumped version to 2.1.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Changelog
 =========
 
 
+2.1.6.1 (2019-02-11)
+====================
+
+* Upgrade Django to 2.1.6 (fixes CVE-2019-6975)
+  see https://www.djangoproject.com/weblog/2019/feb/11/security-releases/
+  for details
+
+
 2.1.5.3 (2019-01-29)
 ====================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Changelog
 * Upgrade Django to 2.1.7 (fixes CVE-2019-6975)
   see https://www.djangoproject.com/weblog/2019/feb/11/security-releases/
   for details
-* Django 2.1.6 was faulty and skipped, see
+* Django 2.1.6 was faulty and is not provided on Divio Cloud, see
   https://code.djangoproject.com/ticket/30175 for details
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,12 +3,14 @@ Changelog
 =========
 
 
-2.1.6.1 (2019-02-11)
+2.1.7.1 (2019-02-11)
 ====================
 
-* Upgrade Django to 2.1.6 (fixes CVE-2019-6975)
+* Upgrade Django to 2.1.7 (fixes CVE-2019-6975)
   see https://www.djangoproject.com/weblog/2019/feb/11/security-releases/
   for details
+* Django 2.1.6 was faulty and skipped, see
+  https://code.djangoproject.com/ticket/30175 for details
 
 
 2.1.5.3 (2019-01-29)

--- a/aldryn_django/__init__.py
+++ b/aldryn_django/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.1.5.3'
+__version__ = '2.1.6.1'

--- a/aldryn_django/__init__.py
+++ b/aldryn_django/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.1.6.1'
+__version__ = '2.1.7.1'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ else:
 
 REQUIREMENTS = [
     'aldryn-addons',
-    'Django==2.1.6',
+    'Django==2.1.7',
 
     # setup utils
     'dj-database-url',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ else:
 
 REQUIREMENTS = [
     'aldryn-addons',
-    'Django==2.1.5',
+    'Django==2.1.6',
 
     # setup utils
     'dj-database-url',


### PR DESCRIPTION
* Upgrade Django to 2.1.7 (fixes CVE-2019-6975)
  see https://www.djangoproject.com/weblog/2019/feb/11/security-releases/
  for details
