### PR TITLE
Bumped version to 2.1.9.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Changelog
 =========
 
 
+2.1.9.1 (2019-06-03)
+====================
+
+* Upgrade Django to 2.1.9 (fixes CVE-2019-12308)
+  see https://www.djangoproject.com/weblog/2019/jun/03/security-releases/
+  for details
+
+
 2.1.8.1 (2019-04-09)
 ====================
 

--- a/aldryn_django/__init__.py
+++ b/aldryn_django/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.1.8.1'
+__version__ = '2.1.9.1'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ else:
 
 REQUIREMENTS = [
     'aldryn-addons',
-    'Django==2.1.8',
+    'Django==2.1.9',
 
     # setup utils
     'dj-database-url',


### PR DESCRIPTION
* Upgrade Django to 2.1.9 (fixes CVE-2019-12308)
  see https://www.djangoproject.com/weblog/2019/jun/03/security-releases/
  for details
