### PR TITLE
Bumped version to 2.2.4.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@ Changelog
 =========
 
 
+2.2.4.1 (2019-08-05)
+====================
+
+* Upgrade Django to 2.2.4
+  (fixes CVE-2019-14232, CVE-2019-14233, CVE-2019-14234, CVE-2019-14235)
+  see https://www.djangoproject.com/weblog/2019/aug/01/security-releases/
+  for details
+
+
 2.2.3.4 (2019-07-29)
 ====================
 

--- a/aldryn_django/__init__.py
+++ b/aldryn_django/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.2.3.4'
+__version__ = '2.2.4.1'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ else:
 
 REQUIREMENTS = [
     'aldryn-addons',
-    'Django==2.2.3',
+    'Django==2.2.4',
 
     # setup utils
     'dj-database-url',


### PR DESCRIPTION
* Upgrade Django to 2.2.4
  (fixes CVE-2019-14232, CVE-2019-14233, CVE-2019-14234, CVE-2019-14235)
  see https://www.djangoproject.com/weblog/2019/aug/01/security-releases/
  for details
