### PR TITLE
Bumped version to 2.2.7.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-2.2.7.2 (2019-11-11)
+
+2.2.7.2 (2019-11-12)
 ====================
 
 * Added the ``--need-app`` command line flag to the uwsgi startup options

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+2.2.7.2 (2019-11-11)
+====================
+
+* Added the ``--need-app`` command line flag to the uwsgi startup options
+
 
 2.2.7.1 (2019-11-04)
 ====================

--- a/aldryn_django/__init__.py
+++ b/aldryn_django/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.2.7.1'
+__version__ = '2.2.7.2'

--- a/aldryn_django/cli.py
+++ b/aldryn_django/cli.py
@@ -130,6 +130,7 @@ def start_uwsgi_command(settings, port=None):
         '--max-requests={}'.format(settings['DJANGO_WEB_MAX_REQUESTS']),
         '--harakiri={}'.format(settings['DJANGO_WEB_TIMEOUT']),
         '--lazy-apps',
+        '--need-app',
     ]
 
     serve_static = False


### PR DESCRIPTION
This prevents workers which fail to load the app to be considered as
working and put into the rotation.

See also https://github.com/unbit/uwsgi/issues/1172