### PR TITLE
Bumped version to 3.0.0.1.rc1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,13 @@ Changelog
 =========
 
 
+3.0.0.1.rc1 (2019-11-21)
+========================
+
+* Add Django 3.0rc1 (release candidate 1) support
+* Added the ``--need-app`` command line flag to the uwsgi startup options
+
+
 3.0.0.1.b1 (2019-10-21)
 =======================
 

--- a/aldryn_django/__init__.py
+++ b/aldryn_django/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '3.0.0.1.b1'
+__version__ = '3.0.0.1.rc1'

--- a/aldryn_django/cli.py
+++ b/aldryn_django/cli.py
@@ -130,6 +130,7 @@ def start_uwsgi_command(settings, port=None):
         '--max-requests={}'.format(settings['DJANGO_WEB_MAX_REQUESTS']),
         '--harakiri={}'.format(settings['DJANGO_WEB_TIMEOUT']),
         '--lazy-apps',
+        '--need-app',
     ]
 
     serve_static = False

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from aldryn_django import __version__
 
 REQUIREMENTS = [
     'aldryn-addons',
-    'Django==3.0b1',
+    'Django==3.0rc1',
 
     # setup utils
     'dj-database-url',


### PR DESCRIPTION
* Add Django 3.0rc1 (release candidate 1) support
* Added the ``--need-app`` command line flag to the uwsgi startup options
