### PR TITLE
Bumped version to 3.0.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Changelog
 =========
 
 
+3.0.1.1 (2019-12-03)
+====================
+
+* Upgrade Django to 3.0.1 (fixes CVE-2019-19844)
+  see https://www.djangoproject.com/weblog/2019/dec/18/security-releases/
+  for details
+
+
 3.0.0.1 (2019-12-03)
 ====================
 

--- a/aldryn_django/__init__.py
+++ b/aldryn_django/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '3.0.0.1'
+__version__ = '3.0.1.1'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from aldryn_django import __version__
 
 REQUIREMENTS = [
     'aldryn-addons',
-    'Django==3.0.0',
+    'Django==3.0.1',
 
     # setup utils
     'dj-database-url',


### PR DESCRIPTION
* Upgrade Django to 3.0.1 (fixes CVE-2019-19844)
  see https://www.djangoproject.com/weblog/2019/dec/18/security-releases/
  for details