### PR TITLE
Bumped version to 3.0.7.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Changelog
 =========
 
 
+3.0.7.1 (2020-06-04)
+====================
+
+* Upgrade Django to 3.0.7 (fixes CVE-2020-13254, CVE-2020-13596)
+  see https://www.djangoproject.com/weblog/2020/jun/03/security-releases/
+  for details
+
+
 3.0.6.1 (2020-05-04)
 ====================
 

--- a/aldryn_django/__init__.py
+++ b/aldryn_django/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '3.0.6.1'
+__version__ = '3.0.7.1'

--- a/aldryn_django/cli.py
+++ b/aldryn_django/cli.py
@@ -115,7 +115,7 @@ def get_static_serving_args(base_url, root, header_patterns):
         pattern = os.path.join('^', base_path, pattern)
         for k, v in headers.items():
             args.append('--route={} addheader:{}: {}'.format(pattern, k, v))
-        args.append('--route={} last:'.format(pattern, k, v))
+        args.append('--route={} last:'.format(pattern))
 
     return args
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from aldryn_django import __version__
 
 REQUIREMENTS = [
     'aldryn-addons',
-    'Django==3.0.6',
+    'Django==3.0.7',
 
     # setup utils
     'dj-database-url',


### PR DESCRIPTION
* Upgrade Django to 3.0.7 (fixes CVE-2020-13254, CVE-2020-13596)
  see https://www.djangoproject.com/weblog/2020/jun/03/security-releases/
  for details