### PR TITLE
related to #266, warnings for future versions of Python

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+n.n.n / 2022-03-30
+==================
+
+* related to #266, warnings for future versions of Python
+* Update Python syntax for the codebase using pyupgrade tool
+
+
 
 3.2.12.0 (2022-02-01)
 =====================

--- a/aldryn_django/cli.py
+++ b/aldryn_django/cli.py
@@ -32,7 +32,7 @@ def migrate(ctx_obj):
     cmds = ctx_obj['settings']['MIGRATION_COMMANDS']
     click.echo('aldryn-django: running migration commands')
     for cmd in cmds:
-        click.echo('    ----> {}'.format(cmd))
+        click.echo(f'    ----> {cmd}')
         try:
             subprocess.check_call(cmd, shell=True)
         except subprocess.CalledProcessError as exc:
@@ -95,7 +95,7 @@ def get_static_serving_args(base_url, root, header_patterns):
     base_path = str(furl.furl(base_url).path).lstrip('/')
 
     args = [
-        '--static-map=/{}={}'.format(base_path, root),
+        f'--static-map=/{base_path}={root}',
         '--route={} addheader:Vary: Accept-Encoding'.format(
             os.path.join('^', base_path, '.*'),
         ),
@@ -104,8 +104,8 @@ def get_static_serving_args(base_url, root, header_patterns):
     for pattern, headers in header_patterns:
         pattern = os.path.join('^', base_path, pattern)
         for k, v in headers.items():
-            args.append('--route={} addheader:{}: {}'.format(pattern, k, v))
-        args.append('--route={} last:'.format(pattern))
+            args.append(f'--route={pattern} addheader:{k}: {v}')
+        args.append(f'--route={pattern} last:')
 
     return args
 

--- a/aldryn_django/management/commands/aldryn_collectstatic.py
+++ b/aldryn_django/management/commands/aldryn_collectstatic.py
@@ -53,6 +53,6 @@ class Command(BaseCommand):
             if os.path.splitext(path_in)[1] in self.gzip_ext:
                 path_out = path_in + '.gz'
                 with open(path_in, 'rb') as f_in:
-                    self.stdout.write('Compressing {}...'.format(path_in))
+                    self.stdout.write(f'Compressing {path_in}...')
                     with gzip.open(path_out, 'wb') as f_out:
                         shutil.copyfileobj(f_in, f_out)

--- a/aldryn_django/management/commands/aldryn_optimize_static_images.py
+++ b/aldryn_django/management/commands/aldryn_optimize_static_images.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
 
             # Optimize the image
             optimize_command = command.format(filename=temp_image.name)
-            self.stdout.write('>>> {}'.format(optimize_command))
+            self.stdout.write(f'>>> {optimize_command}')
             subprocess.check_call(optimize_command, shell=True)
             self.stdout.write('')
 

--- a/aldryn_django/management/commands/aldryn_update_s3_media_headers.py
+++ b/aldryn_django/management/commands/aldryn_update_s3_media_headers.py
@@ -10,4 +10,4 @@ class Command(BaseCommand):
             raise CommandError('The default media files storage does not '
                                'support updating headers')
         updated, total = default_storage.update_headers()
-        self.stdout.write('{}/{} files updated'.format(updated, total))
+        self.stdout.write(f'{updated}/{total} files updated')

--- a/aldryn_django/middleware.py
+++ b/aldryn_django/middleware.py
@@ -35,7 +35,7 @@ class LanguagePrefixFallbackMiddleware(MiddlewareMixin):
             if path_valid:
                 script_prefix = get_script_prefix()
                 old_path = get_script_prefix() + language_from_path + '/'
-                language_url = "%s://%s%s" % (
+                language_url = "{}://{}{}".format(
                     request.scheme,
                     request.get_host(),
                     # replace the old path which contains language code

--- a/aldryn_django/storage.py
+++ b/aldryn_django/storage.py
@@ -55,7 +55,7 @@ def is_default_storage_on_other_domain():
     return media_host not in settings.ALLOWED_HOSTS if media_host else False
 
 
-class GZippedStaticFilesMixin(object):
+class GZippedStaticFilesMixin:
     """
     Static files storage mixin to create a gzipped version of each static
     file, so that web servers (e.g. uWSGI) can take advantage of it and
@@ -68,7 +68,7 @@ class GZippedStaticFilesMixin(object):
         gz_path = path + ".gz"
         with self.open(path) as f_in:
             with self.open(gz_path, "wb") as f_out:
-                with gzip.GzipFile(fileobj=f_out) as gz_out:
+                with gzip.GzipFile(fileobj=f_out, mode="w") as gz_out:
                     shutil.copyfileobj(f_in, gz_out)
         return gz_path
 
@@ -81,14 +81,13 @@ class GZippedStaticFilesMixin(object):
             yield os.path.join(path, file)
 
     def post_process(self, paths, dry_run=False, **options):
-        superclass = super(GZippedStaticFilesMixin, self)
+        superclass = super()
         if hasattr(superclass, "post_process"):
             post_processed = superclass.post_process(paths, dry_run=dry_run, **options)
         else:
             post_processed = []
 
-        for processed in post_processed:
-            yield processed
+        yield from post_processed
 
         if dry_run:
             return


### PR DESCRIPTION
Add Python3.9+ support for the aldryn-django